### PR TITLE
Implement scrub_vms_extensions

### DIFF
--- a/bonelab/cli/ScrubVMSExtension.py
+++ b/bonelab/cli/ScrubVMSExtension.py
@@ -1,0 +1,74 @@
+
+# Imports
+import argparse
+import os
+import re
+
+from bonelab.util.echo_arguments import echo_arguments
+
+def scrub_vms_extension(input_files, verbose):
+    # Python 2/3 compatible input
+    from six.moves import input
+
+    n_files = len(input_files)
+    if n_files == 0:
+        print('No files supplied. Exiting...')
+        return
+
+    processed = 0
+    skipped = 0
+    pattern = r'(;[0-9]+)$'
+    for filename in input_files:
+        m = re.search(pattern, filename)
+
+        # Match found?
+        if not m:
+            skipped+=1
+            if verbose:
+                print('Skipping ' + filename)
+            continue
+
+        # Format filename
+        extension = m.group(0)
+        new_filename = filename.replace(extension, '')
+
+        # Rename
+        if verbose:
+            print('Renaming ' + filename + ' to ' + new_filename)
+        os.rename(filename, new_filename)
+        processed+=1
+
+    print('Total files:     {}'.format(n_files))
+    print('Processed files: {}'.format(processed))
+    print('Skipped files:   {}'.format(skipped))
+
+def main():
+    # Setup description
+    description='''Remove the version extension from VMS files
+
+Example usage:
+    scrub_vms_extension D0001274_OBLIQUE.TIF;1
+    scrub_vms_extension data/*.AIM*
+
+If one file with multiple versions are found, they will be overwritten. The
+final result will be the last file supplied to this script
+'''
+
+    # Setup argument parsing
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        prog="scrub_vms_extension",
+        description=description
+    )
+    parser.add_argument('input_files', nargs='+', help='Input image')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+
+    # Parse and display
+    args = parser.parse_args()
+    print(echo_arguments('scrub_vms_extension', vars(args)))
+
+    # Run program
+    scrub_vms_extension(**vars(args))
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
     blSliceViewer = bonelab.cli.SliceViewer:main
     blVisualizeSegmentation = bonelab.cli.VisualizeSegmentation:main
     blRapidPrototype = bonelab.cli.RapidPrototype:main
+    scrub_vms_extension = bonelab.cli.ScrubVMSExtension:main
 
 [pbr]
 skip_changelog = 1

--- a/tests/cli/test_cli_setup.py
+++ b/tests/cli/test_cli_setup.py
@@ -59,6 +59,10 @@ class TestCommandLineInterfeceSetup(unittest.TestCase):
         '''Can run `blRapidPrototype`'''
         self.runner('blRapidPrototype')
 
+    def test_scrub_vms_extension(self):
+        '''Can run `scrub_vms_extension`'''
+        self.runner('scrub_vms_extension')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/test_scrub_vms_extension.py
+++ b/tests/cli/test_scrub_vms_extension.py
@@ -1,0 +1,55 @@
+
+import os
+import unittest
+import shutil, tempfile
+import subprocess
+
+
+class TestScrubVMSExtensions(unittest.TestCase):
+    def setUp(self):
+        # Create temporary directory to work in
+        self.test_dir = tempfile.mkdtemp()
+
+        self.input_filenames = [
+            'a.txt', 'b.AIM',
+            'D0001274_OBLIQUE.TIF;1',
+            'RETRO_001572.AIM;1234'
+
+        ]
+        self.output_filenames = [
+            'a.txt', 'b.AIM',
+            'D0001274_OBLIQUE.TIF',
+            'RETRO_001572.AIM'
+        ]
+
+        # Create fake files
+        for filename in self.input_filenames:
+            with open(os.path.join(self.test_dir, filename), 'w') as fp:
+                fp.write('')
+
+        for input_filename, output_filename in zip(self.input_filenames, self.output_filenames):
+            self.assertTrue(os.path.isfile(os.path.join(self.test_dir, input_filename)))
+
+        # Run commands
+        command = ['scrub_vms_extension']
+        for filename in self.input_filenames:
+            command.append(os.path.join(self.test_dir, filename))
+        self.output = subprocess.check_output(command).decode("utf-8")
+
+    def tearDown(self):
+        # Remove temporary directory and all files
+        shutil.rmtree(self.test_dir)
+
+    def test_scrub_vms_extensions_renames_files(self):
+        '''scrub_vms_extensions correctly renames all files'''
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'a.txt')))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'b.AIM')))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'D0001274_OBLIQUE.TIF')))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_dir, 'RETRO_001572.AIM')))
+
+        self.assertFalse(os.path.isfile(os.path.join(self.test_dir, 'D0001274_OBLIQUE.TIF;1')))
+        self.assertFalse(os.path.isfile(os.path.join(self.test_dir, 'RETRO_001572.AIM;1234')))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
FYI @lburt @stevenkboyd 

Reimplementation of [scrub_vms_extension](https://github.com/Bonelab/Bonelab-Old/blob/master/tools/scrub_vms_extension.sh) with python instead of bash. This is probably slower for >100 files (like aix) but works on Windows now and is more integrated into the spirit of the bonelab repository.