### PR TITLE
Nathan/deformable registration

### DIFF
--- a/bonelab/util/multiscale_registration.py
+++ b/bonelab/util/multiscale_registration.py
@@ -99,9 +99,10 @@ def multiscale_registration(
     # If we are doing this with a multiscale progression, work through this progression in order first
     if multiscale_progression is not None:
         for (shrink_factor, smoothing_sigma) in multiscale_progression:
+            resampled_fixed_image = smooth_and_resample(fixed_image, shrink_factor, smoothing_sigma)
+            resampled_moving_image = smooth_and_resample(moving_image, shrink_factor, smoothing_sigma)
             displacement_field = registration_algorithm.Execute(
-                smooth_and_resample(fixed_image, shrink_factor, smoothing_sigma),
-                smooth_and_resample(moving_image, shrink_factor, smoothing_sigma),
+                resampled_fixed_image, resampled_moving_image,
                 sitk.Resample(displacement_field, resampled_fixed_image)
             )
 

--- a/bonelab/util/multiscale_registration.py
+++ b/bonelab/util/multiscale_registration.py
@@ -1,13 +1,22 @@
-'''
+"""
 code source: https://simpleitk.org/SPIE2019_COURSE/05_advanced_registration.html
 
-Modified slightly but mechanically the same as the source.
-'''
+Modified slightly but mechanically the same as the source. Also some extra stuff added to make using it easier.
+"""
 
 from __future__ import annotations
 
 import SimpleITK as sitk
 from typing import Optional, List
+
+
+# a list of Demons registration filters available in SimpleITK
+DEMONS_FILTERS = {
+    "demons": sitk.DemonsRegistrationFilter,
+    "diffeomorphic": sitk.DiffeomorphicDemonsRegistrationFilter,
+    "symmetric": sitk.SymmetricForcesDemonsRegistrationFilter,
+    "fast_symmetric": sitk.FastSymmetricForcesDemonsRegistrationFilter
+}
 
 
 def smooth_and_resample(image: sitk.Image, shrink_factor: float, smoothing_sigma: float) -> sitk.Image:
@@ -108,3 +117,75 @@ def multiscale_registration(
 
     # Finish off by doing one registration at full resolution
     return registration_algorithm.Execute(fixed_image, moving_image, sitk.Resample(displacement_field, fixed_image))
+
+
+def multiscale_demons(
+    fixed_image: sitk.Image,
+    moving_image: sitk.Image,
+    demons_type: str = "demons",
+    demons_iterations: int = 100,
+    demons_displacement_field_smooth_std: Optional[float] = 1.0,
+    demons_update_field_smooth_std: Optional[float] = 1.0,
+    initial_transform: Optional[sitk.Transform] = None,
+    multiscale_progression: Optional[List[Tuple[float, float]]] = None
+) -> sitk.DisplacementFieldTransform:
+    """
+    Perform a multiscale registration using a given registration algorithm and fixed/moving image pair. You can
+    optionally pass in an initial transform and the multiscale progression.
+
+    Parameters
+    ----------
+    fixed_image : sitk.Image
+        A SimpleITK image. The resulting transformation will point from this image's coordinate system into the
+        moving_image's coordinate system.
+
+    moving_image : sitk.Image
+        A SimpleITK image. The resulting transformation will point from the fixed_image's coordinate system into this
+        image's coordinate system.
+
+    demons_type : str
+        Specify what kind of Demons deformable registration filter to use. Default is "demons"
+        Options:
+            "demons": sitk.DemonsRegistrationFilter,
+            "diffeomorphic": sitk.DiffeomorphicDemonsRegistrationFilter,
+            "symmetric": sitk.SymmetricForcesDemonsRegistrationFilter,
+            "fast_symmetric": sitk.FastSymmetricForcesDemonsRegistrationFilter
+
+    demons_iterations : int
+        Maximum number of iterations to run the demons algorithm each time it is called. Default: 100
+
+    demons_displacement_field_smooth_std : Optional[float]
+        The standard deviation of the gaussian applied to the displacement field in the Demons filter as regularization,
+        in physical units. Set this argument to `None` to disable displacement field smoothing. Default: 1.0
+
+    demons_update_field_smooth_std : Optional[float]
+        The standard deviation of the gaussian applied to the update field in the Demons filter as regularization,
+        in physical units. Set this argument to `None` to disable update field smoothing. Default: 1.0
+
+    initial_transform : Optional[sitk.Transform]
+        A SimpleITK transform to initialize the registration with, if provided.
+
+    multiscale_progression : Optional[List[Tuple[float, float]]]
+        A list of tuples that each contain two floats: the first is a shrink factor and the second is a smoothing
+        sigma. If this argument is provided, a series of registrations will be performed on resampled and smoothed
+        images in the order that the shrink factor and smoothing sigma pairs are given, ending with a final registration
+        at full resolution. If this argument is not given then only one registration is performed, at full resolution.
+
+    Returns
+    -------
+    sitk.DisplacementFieldTransform
+        The final transform output by the final registration at full resolution.
+    """
+    demons = DEMONS_FILTERS[demons_type]
+    demons.SetNumberOfIterations(demons_iterations)
+    if demons_displacement_field_smooth_std is not None:
+        demons.SetSmoothDisplacementField(True)
+        demons.SetStandardDeviations(demons_std)
+    else:
+        demons.SetSmoothDisplacementField(False)
+    if demons_update_field_smooth_std is not None:
+        demons.SetSmoothUpdateField(True)
+        demons.SetUpdateFieldStandardDeviations(demons_update_field_smooth_std)
+    else:
+        demons.SetSmoothUpdateField(False)
+    return multiscale_registration(demons, fixed_image, moving_image, initial_transform, multiscale_progression)

--- a/bonelab/util/multiscale_registration.py
+++ b/bonelab/util/multiscale_registration.py
@@ -1,0 +1,109 @@
+'''
+code source: https://simpleitk.org/SPIE2019_COURSE/05_advanced_registration.html
+
+Modified slightly but mechanically the same as the source.
+'''
+
+from __future__ import annotations
+
+import SimpleITK as sitk
+from typing import Optional, List
+
+
+def smooth_and_resample(image: sitk.Image, shrink_factor: float, smoothing_sigma: float) -> sitk.Image:
+    """
+    This function can be used on its own to smooth and resample an image, but it is here mainly because it is used
+    in the `multiscale_registration` function to get down-sampled images.
+
+    Parameters
+    ----------
+    image : sitk.Image
+        The image to resample at a lower resolution.
+
+    shrink_factor : float
+        The multiple by which to shrink the image.
+
+    smoothing_sigma : float
+        The sigma for the gaussian smoothing, in the same physical units as the image spacing.
+
+    Returns
+    -------
+    sitk.Image
+        The filtered and downsampled image.
+    """
+    # compute the size and spacing of the resampled image
+    new_size = [int(sz / float(shrink_factor) + 0.5) for sz in image.GetSize()]
+    new_spacing = [
+        ((osz - 1) * osp) / (nsz - 1)
+        for (osz, osp, nsz) in zip(image.GetSize(), image.GetSpacing(), new_size)
+    ]
+
+    # smooth and resample
+    return sitk.Resample(
+        sitk.SmoothingRecursiveGaussian(image, smoothing_sigma),
+        new_size, sitk.Transform(), sitk.sitkLinear, image.GetOrigin(),
+        new_spacing, image.GetDirection(), 0.0, image.GetPixelID()
+    )
+
+
+def multiscale_registration(
+    registration_algorithm: sitk.ImageFilter,
+    fixed_image: sitk.Image,
+    moving_image: sitk.Image,
+    initial_transform: Optional[sitk.Transform] = None,
+    multiscale_progression: Optional[List[Tuple[float, float]]] = None
+) -> sitk.DisplacementFieldTransform:
+    """
+    Perform a multiscale registration using a given registration algorithm and fixed/moving image pair. You can
+    optionally pass in an initial transform and the multiscale progression.
+
+    Parameters
+    ----------
+    registration_algorithm : sitk.ImageFilter
+        Any registration image filter in SimpleITK that has a method called `Execute` that takes two SimpleITK images
+        and a displacement field image as arguments and which returns a displacement field.
+
+    fixed_image : sitk.Image
+        A SimpleITK image. The resulting transformation will point from this image's coordinate system into the
+        moving_image's coordinate system.
+
+    moving_image : sitk.Image
+        A SimpleITK image. The resulting transformation will point from the fixed_image's coordinate system into this
+        image's coordinate system.
+
+    initial_transform : Optional[sitk.Transform]
+        A SimpleITK transform to initialize the registration with, if provided.
+
+    multiscale_progression : Optional[List[Tuple[float, float]]]
+        A list of tuples that each contain two floats: the first is a shrink factor and the second is a smoothing
+        sigma. If this argument is provided, a series of registrations will be performed on resampled and smoothed
+        images in the order that the shrink factor and smoothing sigma pairs are given, ending with a final registration
+        at full resolution. If this argument is not given then only one registration is performed, at full resolution.
+
+    Returns
+    -------
+    sitk.DisplacementFieldTransform
+        The final transform output by the final registration at full resolution.
+    """
+    # Create initial displacement field
+    # The pixel type is required to be sitkVectorFloat64 because of a constraint imposed by the Demons filters.
+    if initial_transform:
+        displacement_field = sitk.TransformToDisplacementField(
+            initial_transform, sitk.sitkVectorFloat64, fixed_image.GetSize(),
+            fixed_image.GetOrigin(), fixed_image.GetSpacing(), fixed_image.GetDirection()
+        )
+    else:
+        displacement_field = sitk.Image(*fixed_image.GetSize(), sitk.sitkVectorFloat64)
+        displacement_field.CopyInformation(fixed_image)
+
+    # If we are doing this with a multiscale progression, work through this progression in order first
+    if multiscale_progression is not None:
+        for (shrink_factor, smoothing_sigma) in multiscale_progression:
+            displacement_field = registration_algorithm.Execute(
+                smooth_and_resample(fixed_image, shrink_factor, smoothing_sigma),
+                smooth_and_resample(moving_image, shrink_factor, smoothing_sigma),
+                sitk.Resample(displacement_field, resampled_fixed_image)
+            )
+
+    # Finish off by doing one registration at full resolution
+    return registration_algorithm.Execute(fixed_image, moving_image, sitk.Resample(displacement_field, fixed_image))

--- a/bonelab/util/multiscale_registration.py
+++ b/bonelab/util/multiscale_registration.py
@@ -176,11 +176,11 @@ def multiscale_demons(
     sitk.DisplacementFieldTransform
         The final transform output by the final registration at full resolution.
     """
-    demons = DEMONS_FILTERS[demons_type]
+    demons = DEMONS_FILTERS[demons_type]()
     demons.SetNumberOfIterations(demons_iterations)
     if demons_displacement_field_smooth_std is not None:
         demons.SetSmoothDisplacementField(True)
-        demons.SetStandardDeviations(demons_std)
+        demons.SetStandardDeviations(demons_displacement_field_smooth_std)
     else:
         demons.SetSmoothDisplacementField(False)
     if demons_update_field_smooth_std is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pbr
 nose
 six
+hypothesis
 
 # Image processing
 vtk

--- a/tests/util/test_aim_calibration_header.py
+++ b/tests/util/test_aim_calibration_header.py
@@ -116,5 +116,6 @@ Standard data deviation                    1315.35596
 
         self.assertAlmostEqual(b, -3.91209015e+02)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/util/test_multiscale_registration.py
+++ b/tests/util/test_multiscale_registration.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import unittest
-from bonelab.util.multiscale_registration import smooth_and_resample, multiscale_registration
+from hypothesis import given, strategies as st
+from bonelab.util.multiscale_registration import (
+    smooth_and_resample, multiscale_registration, multiscale_demons, DEMONS_FILTERS
+)
 
 import numpy as np
 import SimpleITK as sitk
@@ -15,17 +18,19 @@ def generate_sitk_image(shape: Tuple[int, int, int]) -> sitk.Image:
 
 class TestSmoothAndResample(unittest.TestCase):
 
-    def test_no_shrink(self):
-        shape = (10, 10, 10)
+    @given(d=st.integers(min_value=5, max_value=50))
+    def test_no_shrink(self, d):
+        shape = (d, d, d)
         img = generate_sitk_image(shape)
         resampled_img = smooth_and_resample(img, 1.0, 1.0)
         self.assertEqual(shape, resampled_img.GetSize())
 
-    def test_shrink_by_two(self):
-        shape = (10, 10, 10)
+    @given(d=st.integers(min_value=5, max_value=50), s=st.floats(min_value=1.0, max_value=3.0))
+    def test_arbitrary_shrinkage(self, d, s):
+        shape = (d, d, d)
         img = generate_sitk_image(shape)
-        resampled_img = smooth_and_resample(img, 2.0, 1.0)
-        self.assertEqual( (5, 5, 5), resampled_img.GetSize())
+        resampled_img = smooth_and_resample(img, s, 1.0)
+        self.assertEqual(tuple([int(x / s + 0.5) for x in shape]), resampled_img.GetSize())
 
 
 class TestMultiscaleRegistration(unittest.TestCase):
@@ -38,41 +43,45 @@ class TestMultiscaleRegistration(unittest.TestCase):
         self.registration_filter.SetSmoothUpdateField(True)
         self.registration_filter.SetUpdateFieldStandardDeviations(1.0)
 
-    def test_normal_registration(self):
-        shape = (50, 50, 50)
+    @given(d=st.integers(min_value=20, max_value=50))
+    def test_normal_registration(self, d):
+        shape = (d, d, d)
         fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        multiscale_registration(self.registration_filter, fixed, moving)
+        ddf = multiscale_registration(self.registration_filter, fixed, moving)
+        self.assertEqual(ddf.GetSize(), fixed.GetSize())
 
-    def test_one_multiscale_level(self):
-        shape = (50, 50, 50)
-        multiscale_progression = ((2.0, 1.0),)
+    @given(d=st.integers(min_value=20, max_value=30), n=st.integers(min_value=1, max_value=3))
+    def test_multiscale(self, d, n):
+        shape = (d, d, d)
+        multiscale_progression = tuple(zip(
+            [float((x+1)**2) for x in range(n)], [float((x+1)**2) for x in range(n)]
+        ))
         fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        multiscale_registration(
+        ddf = multiscale_registration(
             self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
         )
-
-    def test_three_multiscale_levels(self):
-        shape = (50, 50, 50)
-        multiscale_progression = ((2.0, 1.0), (4.0, 2.0), (8.0, 4.0))
-        fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        multiscale_registration(
-            self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
-        )
+        self.assertEqual(ddf.GetSize(), fixed.GetSize())
 
 
 class TestMultiscaleDemons(unittest.TestCase):
 
-    def test_demons(self):
-        pass
-
-    def test_diffeomorphic(self):
-        pass
-
-    def test_symmetric(self):
-        pass
-
-    def test_fast_symmetric(self):
-        pass
+    @given(
+        demons_type=st.sampled_from(list(DEMONS_FILTERS.keys())),
+        d=st.integers(min_value=20, max_value=30),
+        n=st.integers(min_value=1, max_value=3),
+        demons_iterations=st.integers(min_value=1, max_value=10)
+    )
+    def test_demons(self, demons_type, d, n, demons_iterations):
+        shape = (d, d, d)
+        multiscale_progression = tuple(zip(
+            [float((x + 1) ** 2) for x in range(n)], [float((x + 1) ** 2) for x in range(n)]
+        ))
+        fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
+        ddf = multiscale_demons(
+            fixed, moving, demons_type, demons_iterations,
+            multiscale_progression=multiscale_progression
+        )
+        self.assertEqual(ddf.GetSize(), fixed.GetSize())
 
 
 if __name__ == '__main__':

--- a/tests/util/test_multiscale_registration.py
+++ b/tests/util/test_multiscale_registration.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import unittest
+from bonelab.util.multiscale_registration import smooth_and_resample, multiscale_registration
+
+import numpy as np
+import SimpleITK as sitk
+
+from typing import Tuple
+
+
+def generate_sitk_image(shape: Tuple[int, int, int]) -> sitk.Image:
+    return sitk.GetImageFromArray(np.random.rand(*shape))
+
+
+class TestSmoothAndResample(unittest.TestCase):
+
+    def test_no_shrink(self):
+        shape = (10, 10, 10)
+        img = generate_sitk_image(shape)
+        resampled_img = smooth_and_resample(img, 1.0, 1.0)
+        self.assertEqual(shape, resampled_img.GetSize())
+
+    def test_shrink_by_two(self):
+        shape = (10, 10, 10)
+        img = generate_sitk_image(shape)
+        resampled_img = smooth_and_resample(img, 2.0, 1.0)
+        self.assertEqual( (5, 5, 5), resampled_img.GetSize())
+
+
+class TestMultiscaleRegistration(unittest.TestCase):
+
+    def setUp(self):
+        self.registration_filter = sitk.DemonsRegistrationFilter()
+        self.registration_filter.SetNumberOfIterations(10)
+        self.registration_filter.SetSmoothDisplacementField(True)
+        self.registration_filter.SetStandardDeviations(1.0)
+        self.registration_filter.SetSmoothUpdateField(True)
+        self.registration_filter.SetUpdateFieldStandardDeviations(1.0)
+
+    def test_normal_registration(self):
+        shape = (50, 50, 50)
+        fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
+        ddf = multiscale_registration(self.registration_filter, fixed, moving)
+
+    def test_one_multiscale_level(self):
+        shape = (50, 50, 50)
+        multiscale_progression = ((2.0, 1.0),)
+        fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
+        ddf = multiscale_registration(
+            self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
+        )
+
+    def test_three_multiscale_levels(self):
+        shape = (50, 50, 50)
+        multiscale_progression = ((2.0, 1.0), (4.0, 2.0), (8.0, 4.0))
+        fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
+        ddf = multiscale_registration(
+            self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/util/test_multiscale_registration.py
+++ b/tests/util/test_multiscale_registration.py
@@ -41,13 +41,13 @@ class TestMultiscaleRegistration(unittest.TestCase):
     def test_normal_registration(self):
         shape = (50, 50, 50)
         fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        ddf = multiscale_registration(self.registration_filter, fixed, moving)
+        multiscale_registration(self.registration_filter, fixed, moving)
 
     def test_one_multiscale_level(self):
         shape = (50, 50, 50)
         multiscale_progression = ((2.0, 1.0),)
         fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        ddf = multiscale_registration(
+        multiscale_registration(
             self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
         )
 
@@ -55,9 +55,24 @@ class TestMultiscaleRegistration(unittest.TestCase):
         shape = (50, 50, 50)
         multiscale_progression = ((2.0, 1.0), (4.0, 2.0), (8.0, 4.0))
         fixed, moving = generate_sitk_image(shape), generate_sitk_image(shape)
-        ddf = multiscale_registration(
+        multiscale_registration(
             self.registration_filter, fixed, moving, multiscale_progression=multiscale_progression
         )
+
+
+class TestMultiscaleDemons(unittest.TestCase):
+
+    def test_demons(self):
+        pass
+
+    def test_diffeomorphic(self):
+        pass
+
+    def test_symmetric(self):
+        pass
+
+    def test_fast_symmetric(self):
+        pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Doing two things with this PR.

1. Adding some convenience code for multiscale registration with SimpleITK in general and for multiscale deformable demons registration specifically. I figured it's better in this repo where everyone can use it rather than just being in one of my project repositories where it will get forgotten about.

2. Adding `hypothesis` to the requirements and using it for automated testing. This is a very powerful package for defining parameter spaces for unit tests rather than having to manually define a bunch of arbitrary test data. Could be useful for generating unit tests for other components in Bonelab and in Ogo potentially.

The multiscale registration code is based on this: https://simpleitk.org/SPIE2019_COURSE/05_advanced_registration.html

I acknowledge and link to it at the top of the new file I am adding, but I wanted to check before I merge this into Bonelab that it's OK to add this here even though it's based on code from elsewhere. I think it's generally useful enough that we would want to have it in a central repo rather than everyone having to copy and paste it if thewy want to use it, but I also don't want to make it look like we or I am taking credit for writing the code.