### PR TITLE
Nathan/add adaptive local thresh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,8 @@ with the :code:`bl` environment activated.
      - apply a transformation to an image
    * - :code:`blRegistrationLongitudinal`
      - perform (rigid) longitudinal registration on a time series of images
+   * - :code:`blAdaptiveLocalThresholding`
+     - segment bone from an AIM using adaptive local thresholding
 
 Running Tests
 =============

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,8 @@ with the :code:`bl` environment activated.
      - perform (rigid) longitudinal registration on a time series of images
    * - :code:`blAdaptiveLocalThresholding`
      - segment bone from an AIM using adaptive local thresholding
+   * - :code:`blFFTLaplaceHamming`
+     - segment bone from an AIM using FFT Laplace Hamming filtering
 
 Running Tests
 =============

--- a/bonelab/cli/adaptive_local_thresholding.py
+++ b/bonelab/cli/adaptive_local_thresholding.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+# external imports
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace
+import SimpleITK as sitk
+from vtkbone import vtkboneAIMReader, vtkboneAIMWriter
+from vtk import VTK_CHAR
+import os
+import numpy as np
+from scipy import ndimage
+from skimage.filters import gaussian
+from skimage.morphology import ball, cube, remove_small_objects
+from datetime import datetime
+
+# internal imports
+from bonelab.util.registration_util import message_s
+from bonelab.util.echo_arguments import echo_arguments
+from bonelab.util.registration_util import create_file_extension_checker
+from bonelab.util.vtk_util import vtkImageData_to_numpy, numpy_to_vtkImageData
+from bonelab.util.aim_calibration_header import get_aim_density_equation
+from bonelab.io.vtk_helpers import handle_filetype_writing_special_cases
+
+
+def calculate_minmax_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
+    """
+    Calculate the minmax threshold image.
+
+    Parameters
+    ----------
+    density : np.ndarray
+        The density image to be thresholded.
+
+    footprint : np.ndarray
+        The footprint to use for identifying local thresholds.
+
+    silent : bool
+        Whether to suppress terminal output.
+
+    Returns
+    -------
+    np.ndarray
+        The minmax threshold image.
+    """
+    message_s("Calculating max image...", silent)
+    max_image = ndimage.filters.maximum_filter(density, footprint=footprint)
+    message_s("Calculating min image...", silent)
+    min_image = ndimage.filters.maximum_filter(density, footprint=footprint)
+    message_s("Calculating minmax threshold image...", silent)
+    return (min_image + max_image) / 2
+
+
+def calculate_mean_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
+    """
+    Calculate the mean threshold image.
+
+    Parameters
+    ----------
+    density : np.ndarray
+        The density image to be thresholded.
+
+    footprint : np.ndarray
+        The footprint to use for identifying local thresholds.
+
+    silent : bool
+        Whether to suppress terminal output.
+
+    Returns
+    -------
+    np.ndarray
+        The mean threshold image.
+    """
+    message_s("Calculating mean image...", silent)
+    return ndimage.filters.convolve(density, footprint / footprint.sum())
+
+
+def compute_adaptive_local_threshold_segmentation(
+        density: np.ndarray,
+        low_threshold: float,
+        high_threshold: float,
+        footprint: np.ndarray,
+        mode: str,
+        sigma: float,
+        min_size: int,
+        silent: bool
+) -> np.ndarray:
+    """
+    Perform local adaptive thresholding on a density image.
+
+    Parameters
+    ----------
+    density : np.ndarray
+        The density image to be thresholded.
+
+    low_threshold : float
+        The lower threshold for the density image.
+
+    high_threshold : float
+        The upper threshold for the density image.
+
+    footprint : np.ndarray
+        The footprint to use for identifying local thresholds.
+
+    mode : str
+        The mode to use for identifying local thresholds. Can be `mean`, `minmax`, or `both`.
+
+    sigma : float
+        The sigma to use for the gaussian filter.
+
+    min_size : int
+        The minimum size of structures to keep in the segmentation.
+
+    silent : bool
+        Whether to suppress terminal output.
+
+    Returns
+    -------
+    np.ndarray
+        The thresholded image.
+    """
+    message_s(f"Calculating threshold image using mode: {mode}", silent)
+    if mode == "mean":
+        threshold_image = calculate_mean_threshold_image(density, footprint, silent)
+    elif mode == "minmax":
+        threshold_image = calculate_minmax_threshold_image(density, footprint, silent)
+    elif mode == "both":
+        threshold_image = np.minimum(
+            calculate_mean_threshold_image(density, footprint, silent),
+            calculate_minmax_threshold_image(density, footprint, silent)
+        )
+    else:
+        raise ValueError(f"`mode` must be one of `mean`, `minmax`, or `both`, received {mode}.")
+    density = gaussian(density, sigma=sigma)
+    return remove_small_objects(
+        ((density > low_threshold) & (density > threshold_image)) | (density > high_threshold),
+        min_size=min_size
+    )
+
+
+def adaptive_local_thresholding(args: Namespace):
+    print(echo_arguments("Adaptive Local Thresholding", vars(args)))
+    if not os.path.exists(args.input):
+        raise FileNotFoundError(f"Input file {args.input} does not exist.")
+    if os.path.exists(args.output) and not args.overwrite:
+        raise FileExistsError(f"Output file {args.output} already exists. Use the --overwrite flag to overwrite.")
+    message_s(f"Reading input image from {args.input}", args.silent)
+    if args.aims:
+        reader = vtkboneAIMReader()
+        reader.DataOnCellsOff()
+        reader.SetFileName(args.input)
+        reader.Update()
+        image = vtkImageData_to_numpy(reader.GetOutput())
+        if args.convert_to_density:
+            m, b = get_aim_density_equation(reader.GetProcessingLog())
+            image = m * image + b
+    else:
+        image_sitk = sitk.ReadImage(args.input)
+        image = sitk.GetArrayFromImage(image_sitk)
+    message_s("Generating bone segmentation", args.silent)
+    if args.structuring_element_shape == "ball":
+        footprint = ball(args.structuring_element_size)
+    elif args.structuring_element_shape == "cube":
+        footprint = cube(args.structuring_element_size)
+    else:
+        raise ValueError("Invalid structuring element shape.")
+    segmentation = compute_adaptive_local_threshold_segmentation(
+        image,
+        args.lower_threshold,
+        args.upper_threshold,
+        footprint,
+        args.local_threshold_method,
+        args.sigma,
+        args.minimum_structure_size,
+        args.silent
+    )
+    message_s(f"Writing bone segmentation to {args.output}", args.silent)
+    if args.aims:
+        segmentation_vtk = numpy_to_vtkImageData(
+            127 * (segmentation > 0),
+            spacing=reader.GetOutput().GetSpacing(),
+            origin=reader.GetOutput().GetOrigin(),
+            array_type=VTK_CHAR
+        )
+        processing_log = (
+            reader.GetProcessingLog() + os.linesep +
+            f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]" +
+            echo_arguments("Bone segmentation created by Adaptive Local Thresholding", vars(args))
+        )
+        writer = vtkboneAIMWriter()
+        writer.SetInputData(segmentation_vtk)
+        handle_filetype_writing_special_cases(
+            writer,
+            processing_log=processing_log
+        )
+        writer.SetFileName(args.output)
+        writer.Update()
+    else:
+        segmentation_sitk = sitk.GetImageFromArray(segmentation)
+        segmentation_sitk.CopyInformation(image_sitk)
+        sitk.WriteImage(segmentation_sitk, args.output)
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        description="Perform adaptive local thresholding on an image to segment bone. You provide an input image "
+                    "and lower and upper thresholds and a bone segmentation will be created. Optionally you can "
+                    "specify the size and shape of the structuring element used for identifying the local thresholds, "
+                    "as well as the minimum structure size to keep in the segmentation. Finally, you can also specify "
+                    "whether to base the local thresholds on the mean of local voxels, the average of the min and max "
+                    "of local voxels, or the minimum of each of these methods. This method is based on the following "
+                    "article: https://doi.org/10.1016/j.bone.2021.116225. ",
+        formatter_class=ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "input",
+        type=str,
+        help="Input image filename to be segmented."
+    )
+    parser.add_argument(
+        "output",
+        type=str,
+        help="Output filename for the segmentation."
+    )
+    parser.add_argument(
+        "--aims",
+        default=False,
+        action="store_true",
+        help="Enable this flag to indicate that the input and output are .aim files."
+    )
+    parser.add_argument(
+        "--lower-threshold", "-lt",
+        type=float,
+        default=190,
+        help="Lower threshold for bone segmentation."
+    )
+    parser.add_argument(
+        "--upper-threshold", "-ut",
+        type=float,
+        default=450,
+        help="Upper threshold for bone segmentation."
+    )
+    parser.add_argument(
+        "--structuring-element-size", "-sz",
+        type=int,
+        default=6,
+        help="Size of the structuring element used for identifying local thresholds."
+             "If the footprint shape is a ball, this is the radius. If the footprint shape is a cube, "
+             "this is the width."
+    )
+    parser.add_argument(
+        "--structuring-element-shape", "-sh",
+        type=str,
+        default="ball",
+        choices=["ball", "cube"],
+        help="Shape of the structuring element used for identifying local thresholds."
+    )
+    parser.add_argument(
+        "--sigma", "-sg",
+        type=float,
+        default=1,
+        help="Sigma for the gaussian filter."
+    )
+    parser.add_argument(
+        "--minimum-structure-size", "-ms",
+        type=int,
+        default=64,
+        help="Minimum size of structures to keep in the segmentation."
+    )
+    parser.add_argument(
+        "--local-threshold-method", "-ltm",
+        type=str,
+        default="mean",
+        choices=["mean", "minmax", "both"],
+        help="Method for determining local thresholds. `mean` uses the mean of local voxels. `minmax` uses the "
+             "average of the min and max of local voxels. `both` uses the minimum of both methods."
+    )
+    parser.add_argument(
+        "--convert-to-density", "-cd",
+        default=False,
+        action="store_true",
+        help="Enable this flag to convert the input aim image to density units. Only valid if the input is an .aim "
+    )
+    parser.add_argument(
+        "--silent", "-s",
+        default=False,
+        action="store_true",
+        help="Enable this flag to suppress terminal output about how the program is proceeding."
+    )
+    parser.add_argument(
+        "--overwrite", "-ow",
+        default=False,
+        action="store_true",
+        help="Enable this flag to overwrite existing files, if they exist at output targets."
+    )
+
+    return parser
+
+
+def main():
+    args = create_parser().parse_args()
+    adaptive_local_thresholding(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bonelab/cli/adaptive_local_thresholding.py
+++ b/bonelab/cli/adaptive_local_thresholding.py
@@ -21,7 +21,7 @@ from bonelab.util.aim_calibration_header import get_aim_density_equation
 from bonelab.io.vtk_helpers import handle_filetype_writing_special_cases
 
 
-def calculate_minmax_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
+def compute_minmax_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
     """
     Calculate the minmax threshold image.
 
@@ -49,7 +49,7 @@ def calculate_minmax_threshold_image(density: np.ndarray, footprint: np.ndarray,
     return (min_image + max_image) / 2
 
 
-def calculate_mean_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
+def compute_mean_threshold_image(density: np.ndarray, footprint: np.ndarray, silent: bool) -> np.ndarray:
     """
     Calculate the mean threshold image.
 
@@ -119,13 +119,13 @@ def compute_adaptive_local_threshold_segmentation(
     """
     message_s(f"Calculating threshold image using mode: {mode}", silent)
     if mode == "mean":
-        threshold_image = calculate_mean_threshold_image(density, footprint, silent)
+        threshold_image = compute_mean_threshold_image(density, footprint, silent)
     elif mode == "minmax":
-        threshold_image = calculate_minmax_threshold_image(density, footprint, silent)
+        threshold_image = compute_minmax_threshold_image(density, footprint, silent)
     elif mode == "both":
         threshold_image = np.minimum(
-            calculate_mean_threshold_image(density, footprint, silent),
-            calculate_minmax_threshold_image(density, footprint, silent)
+            compute_mean_threshold_image(density, footprint, silent),
+            compute_minmax_threshold_image(density, footprint, silent)
         )
     else:
         raise ValueError(f"`mode` must be one of `mean`, `minmax`, or `both`, received {mode}.")

--- a/bonelab/cli/fft_laplace_hamming.py
+++ b/bonelab/cli/fft_laplace_hamming.py
@@ -8,6 +8,7 @@ from vtk import VTK_CHAR
 import os
 import numpy as np
 from datetime import datetime
+from skimage.morphology import remove_small_objects
 
 # internal imports
 from bonelab.util.registration_util import message_s
@@ -199,14 +200,8 @@ def create_parser() -> ArgumentParser:
     parser.add_argument(
         "--min-size", "-ms",
         type=int,
-        default=100,
+        default=64,
         help="The minimum size of the objects to keep."
-    )
-    parser.add_argument(
-        "--silent", "-s",
-        default=False,
-        action="store_true",
-        help="Enable this flag to silence all output."
     )
     parser.add_argument(
         "--convert-to-density", "-cd",
@@ -226,6 +221,7 @@ def create_parser() -> ArgumentParser:
         action="store_true",
         help="Enable this flag to overwrite existing files, if they exist at output targets."
     )
+    return parser
 
 
 def main() -> None:

--- a/bonelab/cli/fft_laplace_hamming.py
+++ b/bonelab/cli/fft_laplace_hamming.py
@@ -121,7 +121,7 @@ def fft_laplace_hamming(args: Namespace) -> None:
         processing_log = (
                 reader.GetProcessingLog() + os.linesep +
                 f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]" +
-                echo_arguments("Bone segmentation created by Adaptive Local Thresholding", vars(args))
+                echo_arguments("Bone segmentation created by FFT Laplace Hamming", vars(args))
         )
         writer = vtkboneAIMWriter()
         writer.SetInputData(segmentation_vtk)

--- a/bonelab/cli/fft_laplace_hamming.py
+++ b/bonelab/cli/fft_laplace_hamming.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+# external imports
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace
+import SimpleITK as sitk
+from vtkbone import vtkboneAIMReader, vtkboneAIMWriter
+from vtk import VTK_CHAR
+import os
+import numpy as np
+from datetime import datetime
+
+# internal imports
+from bonelab.util.registration_util import message_s
+from bonelab.util.echo_arguments import echo_arguments
+from bonelab.util.registration_util import create_file_extension_checker
+from bonelab.util.vtk_util import vtkImageData_to_numpy, numpy_to_vtkImageData
+from bonelab.util.aim_calibration_header import get_aim_density_equation
+from bonelab.io.vtk_helpers import handle_filetype_writing_special_cases
+
+
+def compute_fft_laplace_hamming_segmentation(
+        image: np.ndarray,
+        laplace_epsilon: float,
+        hamming_a0: float,
+        voxel_spacing: float,
+        threshold: float,
+        min_size: int,
+        silent: bool
+) -> np.ndarray:
+    """
+    Compute the FFT Laplace Hamming segmentation of an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        The image to segment.
+
+    laplace_epsilon : float
+        The epsilon value to use to combine the original image and the laplace image.
+
+    hamming_a0 : float
+        The a0 value to use for the hamming window.
+
+    voxel_spacing : float
+        The voxel spacing of the image.
+
+    threshold : float
+        The threshold to use for the segmentation.
+
+    min_size : int
+        The minimum size of the objects to keep.
+
+    silent : bool
+        Whether or not to print messages.
+
+    Returns
+    -------
+    np.ndarray
+        The segmented image.
+    """
+    x, y, z = np.meshgrid(
+        *[np.arange(s) / s for s in image.shape],
+        indexing="ij"
+    )
+    vx, vy, vz = np.meshgrid(
+        *[np.fft.fftshift(np.fft.fftfreq(s, d=voxel_spacing)) for s in image.shape],
+        indexing="ij"
+    )
+    hamming = (
+            (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * x))
+            * (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * y))
+            * (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * z))
+    )
+    laplace_hamming = laplace_epsilon * np.real(np.fft.ifftn(np.fft.ifftshift(
+        hamming * (vx ** 2 + vy ** 2 + vz ** 2) * np.fft.fftshift(np.fft.fftn(image))
+    ))) + (1 - laplace_epsilon) * image
+    return remove_small_objects(laplace_hamming > threshold, min_size=min_size)
+
+
+def fft_laplace_hamming(args: Namespace) -> None:
+    pass
+
+
+def create_parser() -> ArgumentParser:
+    pass
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+    fft_laplace_hamming(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bonelab/cli/fft_laplace_hamming.py
+++ b/bonelab/cli/fft_laplace_hamming.py
@@ -58,6 +58,7 @@ def compute_fft_laplace_hamming_segmentation(
     np.ndarray
         The segmented image.
     """
+    message_s("Construct mesh grids for spatial and frequency domains...", silent)
     x, y, z = np.meshgrid(
         *[np.arange(s) / s for s in image.shape],
         indexing="ij"
@@ -66,23 +67,165 @@ def compute_fft_laplace_hamming_segmentation(
         *[np.fft.fftshift(np.fft.fftfreq(s, d=voxel_spacing)) for s in image.shape],
         indexing="ij"
     )
+    message_s("Construct the hamming window function...", silent)
     hamming = (
             (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * x))
             * (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * y))
             * (hamming_a0 - (1 - hamming_a0) * np.cos(2 * np.pi * z))
     )
+    message_s("Compute the FFT Laplace-Hamming filter...", silent)
     laplace_hamming = laplace_epsilon * np.real(np.fft.ifftn(np.fft.ifftshift(
         hamming * (vx ** 2 + vy ** 2 + vz ** 2) * np.fft.fftshift(np.fft.fftn(image))
     ))) + (1 - laplace_epsilon) * image
+    message_s("Segment and remove small objects from segmentation...", silent)
     return remove_small_objects(laplace_hamming > threshold, min_size=min_size)
 
 
 def fft_laplace_hamming(args: Namespace) -> None:
-    pass
+    print(echo_arguments("FFT Laplace-Hamming", vars(args)))
+    if not os.path.exists(args.input):
+        raise FileNotFoundError(f"Input file {args.input} does not exist.")
+    if os.path.exists(args.output) and not args.overwrite:
+        raise FileExistsError(f"Output file {args.output} already exists. Use the --overwrite flag to overwrite.")
+    message_s(f"Reading input image from {args.input}", args.silent)
+    if args.aims:
+        reader = vtkboneAIMReader()
+        reader.DataOnCellsOff()
+        reader.SetFileName(args.input)
+        reader.Update()
+        image = vtkImageData_to_numpy(reader.GetOutput())
+        if args.convert_to_density:
+            m, b = get_aim_density_equation(reader.GetProcessingLog())
+            image = m * image + b
+    else:
+        image_sitk = sitk.ReadImage(args.input)
+        image = sitk.GetArrayFromImage(image_sitk)
+    segmentation = compute_fft_laplace_hamming_segmentation(
+        image,
+        args.laplace_epsilon,
+        args.hamming_a0,
+        args.voxel_spacing,
+        args.threshold,
+        args.min_size,
+        args.silent
+    )
+    message_s(f"Writing bone segmentation to {args.output}", args.silent)
+    if args.aims:
+        segmentation_vtk = numpy_to_vtkImageData(
+            127 * (segmentation > 0),
+            spacing=reader.GetOutput().GetSpacing(),
+            origin=reader.GetOutput().GetOrigin(),
+            array_type=VTK_CHAR
+        )
+        processing_log = (
+                reader.GetProcessingLog() + os.linesep +
+                f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}]" +
+                echo_arguments("Bone segmentation created by Adaptive Local Thresholding", vars(args))
+        )
+        writer = vtkboneAIMWriter()
+        writer.SetInputData(segmentation_vtk)
+        handle_filetype_writing_special_cases(
+            writer,
+            processing_log=processing_log
+        )
+        writer.SetFileName(args.output)
+        writer.Update()
+    else:
+        segmentation_sitk = sitk.GetImageFromArray(segmentation)
+        segmentation_sitk.CopyInformation(image_sitk)
+        sitk.WriteImage(segmentation_sitk, args.output)
 
 
 def create_parser() -> ArgumentParser:
-    pass
+    parser = ArgumentParser(
+        description="Perform Laplace-Hamming filtering on an AIM to segment bone. You provide an input image, the "
+                    "Laplace epsilon, the Hamming window a0, the voxel spacing, the threshold, and the minimum size "
+                    "for structures in the segmentation, and a segmentation will be created. This is intended to "
+                    "replicate the Laplace Hamming filter available in IPL, and is necessary because the IPL LH "
+                    "filter cannot currently be ran on large images (e.g. from knees). Because IPL is closed-source, "
+                    "we cannot be sure that this implementation is identical. We have just matched the processing "
+                    "steps described in the IPL documentation as best we can.",
+        formatter_class=ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "input",
+        type=str,
+        help="Input image filename to be segmented."
+    )
+    parser.add_argument(
+        "output",
+        type=str,
+        help="Output filename for the segmentation."
+    )
+    parser.add_argument(
+        "--aims",
+        default=False,
+        action="store_true",
+        help="Enable this flag to indicate that the input and output are .aim files."
+    )
+    parser.add_argument(
+        "--laplace-epsilon", "-le",
+        type=float,
+        default=0.5,
+        help="The epsilon value to use to combine the original image and the laplace image."
+    )
+    parser.add_argument(
+        "--hamming-a0", "-ha0",
+        type=float,
+        default=25/46,
+        help="The a0 value to use for the hamming window."
+    )
+    parser.add_argument(
+        "--voxel-spacing", "-vs",
+        type=float,
+        default=1,
+        help="The voxel spacing of the image. This parameter will be used to scale the spatial wavemodes when the "
+             "image is transformed to the frequency domain, and the wavemodes are then squared, summed, and multiplied "
+             "by the image in the frequency domain - to perform the FFT Laplacian filter. "
+             "NOTE: We have found that when this is left at 1, the magnitude "
+             "of the outputs of the FFT Laplace-Hamming filter are on the same order as the original image and so we "
+             "currently recommend this not be modified. If you do modify this, you will need to modify the threshold "
+             "accordingly, and the effect of the `laplace-epsilon` parameter will likely become negligible."
+    )
+    parser.add_argument(
+        "--threshold", "-t",
+        type=float,
+        default=150,
+        help="The threshold to use for the segmentation. NOTE: Do not assume this is in the same units as the input "
+             "image. The  `laplace-epsilon`, `hamming-a0`, and `voxel_spacing` parameters will influence the magnitude "
+             "of the output of the FFT Laplace-Hamming filter, and so the threshold will need to be adjusted "
+             "accordingly."
+    )
+    parser.add_argument(
+        "--min-size", "-ms",
+        type=int,
+        default=100,
+        help="The minimum size of the objects to keep."
+    )
+    parser.add_argument(
+        "--silent", "-s",
+        default=False,
+        action="store_true",
+        help="Enable this flag to silence all output."
+    )
+    parser.add_argument(
+        "--convert-to-density", "-cd",
+        default=False,
+        action="store_true",
+        help="Enable this flag to convert the input aim image to density units. Only valid if the input is an .aim "
+    )
+    parser.add_argument(
+        "--silent", "-s",
+        default=False,
+        action="store_true",
+        help="Enable this flag to suppress terminal output about how the program is proceeding."
+    )
+    parser.add_argument(
+        "--overwrite", "-ow",
+        default=False,
+        action="store_true",
+        help="Enable this flag to overwrite existing files, if they exist at output targets."
+    )
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,11 @@ hypothesis
 vtk
 simpleitk >= 2.1
 pydicom
+scikit-image
 
 # Numerics
 numpy
+scipy
 matplotlib
 
 # Data

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ console_scripts =
     blRegistrationDemons = bonelab.cli.demons_registration:main
     blRegistrationApplyTransform = bonelab.cli.apply_sitk_transform:main
     blRegistrationLongitudinal = bonelab.cli.longitudinal_registration:main
+    blAdaptiveLocalThresholding = bonelab.cli.adaptive_local_thresholding:main
 
 [pbr]
 skip_changelog = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ console_scripts =
     blRegistrationApplyTransform = bonelab.cli.apply_sitk_transform:main
     blRegistrationLongitudinal = bonelab.cli.longitudinal_registration:main
     blAdaptiveLocalThresholding = bonelab.cli.adaptive_local_thresholding:main
+    blFFTLaplaceHamming = bonelab.cli.fft_laplace_hamming:main
 
 [pbr]
 skip_changelog = 1

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -113,6 +113,14 @@ class TestCommandLineInterfaceRun(unittest.TestCase):
         self.runner(command)
         self.assertTrue(os.path.exists(f"{out}.mp4") or os.path.exists(f"{out}.gif"))
 
+    def test_blAdaptiveLocalThresholding(self):
+        """Can run `blAdaptiveLocalThresholding`"""
+        aim = os.path.join(self.test_dir, 'test25a.aim')
+        out = os.path.join(self.test_dir, 'test25a_seg.aim')
+        command = ['blAdaptiveLocalThresholding', aim, out, "--aims"]
+        self.runner(command)
+        self.assertTrue(out, 'Cannot find file ' + out)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -121,6 +121,14 @@ class TestCommandLineInterfaceRun(unittest.TestCase):
         self.runner(command)
         self.assertTrue(out, 'Cannot find file ' + out)
 
+    def test_blFFTLaplaceHamming(self):
+        """Can run `blFFTLaplaceHamming`"""
+        aim = os.path.join(self.test_dir, 'test25a.aim')
+        out = os.path.join(self.test_dir, 'test25a_seg.aim')
+        command = ['blFFTLaplaceHamming', aim, out, "--aims"]
+        self.runner(command)
+        self.assertTrue(out, 'Cannot find file ' + out)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/test_cli_setup.py
+++ b/tests/cli/test_cli_setup.py
@@ -121,6 +121,10 @@ class TestCommandLineInterfeceSetup(unittest.TestCase):
         ''' Can run `blAdaptiveLocalThresholding` '''
         self.runner('blAdaptiveLocalThresholding')
 
+    def test_blFFTLaplaceHamming(self):
+        ''' Can run `blFFTLaplaceHamming` '''
+        self.runner('blFFTLaplaceHamming')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli/test_cli_setup.py
+++ b/tests/cli/test_cli_setup.py
@@ -117,6 +117,10 @@ class TestCommandLineInterfeceSetup(unittest.TestCase):
         ''' Can run `blImageComputeOverlap` '''
         self.runner('blImageComputeOverlap')
 
+    def test_blAdaptiveLocalThresholding(self):
+        ''' Can run `blAdaptiveLocalThresholding` '''
+        self.runner('blAdaptiveLocalThresholding')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding two more utilities, both for segmenting bone from AIMs (or also other SimpleITK-compatible image types).

`blAdaptiveLocalThresholding`
Based on some code provided by @wallematthias and on the article: https://doi.org/10.1016/j.bone.2021.116225
Use a lower threshold to identify voxels that might be bone, then do some convolutional filtering to find the min/mean/max of intensities in neighborhoods around candidate voxels to segment, then combine this with a standard global threshold segmentation using a higher threshold.

`blFFTLaplaceHamming`
An attempted replication of the LH filter in IPL.

Here's an example of the filters applied to a radius AIM with not much motion / noise, compared with the `seg_gauss` segmentation created with IPL as part of the strandard analysis.

Laplace Hamming: epsilon = 0.45, a0 = 0.3
Adaptive: Lower threshold = 190, higher threshold = 450

![image](https://github.com/Bonelab/Bonelab/assets/24441644/486ed2af-bf2f-414d-9d71-710c9ee9fb0d)

The main purpose of these utilities will be for creating bone segmentations in knee images, to see if the reproducibility of voidspace analysis increases with "better" segmentations of the trabeculae.
