### PR TITLE
Nathan/add treece

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Install
 
     # Activate the environemnt
     conda activate bl
-    
+
     # change directory into the Bonelab repo
     cd Bonelab
 
@@ -170,6 +170,8 @@ with the :code:`bl` environment activated.
      - segment bone from an AIM using adaptive local thresholding
    * - :code:`blFFTLaplaceHamming`
      - segment bone from an AIM using FFT Laplace Hamming filtering
+   * - :code:`blTreeceThickness`
+     - compute cortical thickness from a NiFTI and some masks using the Treece method
 
 Running Tests
 =============
@@ -209,4 +211,3 @@ To add a new application, do the following:
 - Add file with main function in bonelab.cli
 - Rerun `pip install -e .`
 - Add tests to tests.cli. test_cli_setup.py and, if appropriate, add other tests.
-

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ with the :code:`bl` environment activated.
    * - :code:`blFFTLaplaceHamming`
      - segment bone from an AIM using FFT Laplace Hamming filtering
    * - :code:`blTreeceThickness`
-     - compute cortical thickness from a NiFTI and some masks using the Treece method
+     - compute cortical thickness from an image and bone segmentation using the Treece method
 
 Running Tests
 =============

--- a/bonelab/cli/DownloadData.py
+++ b/bonelab/cli/DownloadData.py
@@ -36,22 +36,6 @@ def DownloadData(url, output_directory, no_verify):
             output_directory
         )
     shutil.rmtree(os.path.join(output_directory, "BonelabData"))
-    '''
-    command = ['svn', 'export', '--force', url, output_directory]
-    failed = False
-    try:
-        output = subprocess.check_output(command)
-    except subprocess.CalledProcessError as e:
-        failed = True
-    except OSError as e:
-        failed = True
-
-    if failed:
-        os.sys.exit('[ERROR] Could not execute download. Do you have SVN installed?')
-
-    if not os.path.isdir(output_directory):
-        os.sys.exit('[ERROR] An unkown error occured where the output directory was not created')
-    '''
 
     print('Successfully downloaded')
 

--- a/bonelab/cli/DownloadData.py
+++ b/bonelab/cli/DownloadData.py
@@ -2,7 +2,9 @@
 # Imports
 import argparse
 import os
+import shutil
 import subprocess
+from git import Repo
 
 from bonelab.util.echo_arguments import echo_arguments
 from bonelab.io.download_data import \
@@ -11,7 +13,7 @@ from bonelab.io.download_data import \
 def DownloadData(url, output_directory, no_verify):
     # Python 2/3 compatible input
     from six.moves import input
-    
+
     if not no_verify:
         print('Locations:')
         print('  url:              {}'.format(url))
@@ -26,6 +28,15 @@ def DownloadData(url, output_directory, no_verify):
         os.makedirs(output_directory)
 
     # Run commands
+    repo = Repo.clone_from(url, os.path.join(output_directory, "BonelabData"))
+    data_files = os.listdir(os.path.join(output_directory, "BonelabData", "data"))
+    for data_file in data_files:
+        shutil.move(
+            os.path.join(output_directory, "BonelabData", "data", data_file),
+            output_directory
+        )
+    shutil.rmtree(os.path.join(output_directory, "BonelabData"))
+    '''
     command = ['svn', 'export', '--force', url, output_directory]
     failed = False
     try:
@@ -37,9 +48,10 @@ def DownloadData(url, output_directory, no_verify):
 
     if failed:
         os.sys.exit('[ERROR] Could not execute download. Do you have SVN installed?')
-    
+
     if not os.path.isdir(output_directory):
         os.sys.exit('[ERROR] An unkown error occured where the output directory was not created')
+    '''
 
     print('Successfully downloaded')
 

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -444,6 +444,40 @@ def sample_all_intensity_profiles(
     constrain_normal_to_xy: bool,
     silent: bool
 ):
+    '''
+    Sample intensity profiles along lines in the image.
+
+    Parameters
+    ----------
+    image : pv.UniformGrid
+        The image to sample from.
+
+    points : np.ndarray
+        The starting points of the lines.
+
+    normals : np.ndarray
+        The normal vectors for the lines.
+
+    outside_dist : float
+        The distance to start sampling from outside the points along the normals.
+
+    inside_dist : float
+        The distance to sample up to inside the points along the normals.
+
+    dx : float
+        The spacing between sample points.
+
+    constrain_normal_to_xy : bool
+        Whether to constrain the normals to the xy plane.
+
+    silent : bool
+        Set this flag to not show the progress bar.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        The sampled intensities and the x values of the sample points.
+    '''
     if constrain_normal_to_xy:
         normals[:,2] = 0
     normals = normals / np.sqrt((normals**2).sum(axis=-1))[:,np.newaxis]
@@ -543,19 +577,9 @@ def treece_thickness(args: Namespace) -> None:
         if args.plot_model_fit_for_point:
             i = args.plot_model_fit_for_point
         is_problem = False
-        normal = surface["Normals"][i,:]
+        normal = surface.point_data["Normals"][i,:]
         if args.constrain_normal_to_xy:
             normal[2] = 0
-        '''
-        intensities, x = sample_intensity_profile(
-            image,
-            surface.points[i,:],
-            normal,
-            args.sample_outside_distance,
-            args.sample_inside_distance,
-            dx
-        )
-        '''
         intensities = intensity_profiles[i]
         x0, x1, model_intensities = treece_fit(
             intensities,
@@ -632,6 +656,7 @@ def treece_thickness(args: Namespace) -> None:
     if ~args.silent:
         message("Calculate mean and standard deviation of thickness...")
     thickness = surface["thickness"][surface["use_point"] == 1]
+    thickness = thickness[thickness > 0]
     mean_thickness = np.mean(thickness)
     std_thickness = np.std(thickness)
 

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -144,6 +144,16 @@ def create_treece_residual_function(
     def residual_function(args: Tuple[float, float, float, float, float]) -> np.ndarray:
         '''
         Compute the residuals between the model and the measured intensities.
+
+        Parameters
+        ----------
+        args : Tuple[float, float, float, float, float]
+            The parameters to fit the model: x0, x1, y0, y2, sigma.
+
+        Returns
+        -------
+        np.ndarray
+            The residuals between the modelled and the sampled intensities.
         '''
         modelled_intensities = model(x, *args)
         mult = np.linspace(residual_boost_factor, 1, len(x))
@@ -236,6 +246,19 @@ def treece_fit(
 
 
 def compute_boundary_mask(mask: np.ndarray) -> np.ndarray:
+    '''
+    Compute a mask of the boundary of the input mask.
+
+    Parameters
+    ----------
+    mask : np.ndarray
+        The input mask.
+
+    Returns
+    -------
+    np.ndarray
+        The mask of the boundary of the input mask.
+    '''
     eroded_mask = binary_erosion(mask, selem=np.ones((3,3,3)))
     return mask - eroded_mask
 
@@ -248,6 +271,34 @@ def sample_intensity_profile(
     inside_dist: float,
     dx: float
 ) -> Tuple[np.ndarray, np.ndarray]:
+    '''
+    Sample an intensity profile along a line in the image.
+
+    Parameters
+    ----------
+    image : pv.UniformGrid
+        The image to sample from.
+
+    point : np.ndarray
+        The starting point of the line.
+
+    normal : np.ndarray
+        The normal vector for the line.
+
+    outside_dist : float
+        The distance to start sampling from outside the point along the normal.
+
+    inside_dist : float
+        The distance to sample up to inside the point along the normal.
+
+    dx : float
+        The spacing between sample points.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        The sampled intensities and the x values of the sample points.
+    '''
     normal = normal / np.sqrt((normal**2).sum())
     x = np.arange(-outside_dist, inside_dist, dx)
     sample_points = pv.PolyData(point[np.newaxis,:] + x[:,np.newaxis]*normal[np.newaxis,:])
@@ -255,7 +306,15 @@ def sample_intensity_profile(
     return np.array(sample_points["NIFTI"]), x
 
 
-def treece_thickness(args: Namespace):
+def treece_thickness(args: Namespace) -> None:
+    '''
+    Compute the cortical thickness using the Treece' model.
+
+    Parameters
+    ----------
+    args : Namespace
+        The parsed command line arguments.
+    '''
     echoed_args = echo_arguments("Treece Thickness", vars(args))
     print(echoed_args)
     input_fns = [args.bone_mask, args.image]

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -683,7 +683,12 @@ def treece_thickness(args: Namespace) -> None:
 def create_parser() -> ArgumentParser:
     parser = ArgumentParser(
         description="Use a modified version of Treece' method (doi:10.1016/j.media.2010.01.003) to compute "
-                    "a cortical thickness map from an image, a bone mask, and an optional sub-mask.",
+                    "a cortical thickness map from an image, a bone mask, and an optional sub-mask."
+                    "The out will be a *.vtk polydata file and a *.log file. The surface can be used to "
+                    "visualize or continue processing the cortical thicknesses. The log file will contain "
+                    "the mean and standard deviation of the thicknesses (for the points where the model "
+                    " could be fit to the data properly) as well as debug information for points where the "
+                    "model failed to fit properly.",
         formatter_class=ArgumentDefaultsHelpFormatter
     )
 

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -525,7 +525,7 @@ def median_smooth_polydata(pd: pv.PolyData, scalar: str, flag_scalar: str, silen
         neighbours[i] = list(set(neighbours[i]))
     out = pd.copy()
     for i in tqdm(np.where(pd[flag_scalar] == 1)[0], disable=silent):
-        flag = pd[flag_scalar][neighbours[i]]
+        flag = pd[flag_scalar][neighbours[i]] * (pd[scalar][neighbours[i]] > 0)
         vals = pd[scalar][neighbours[i]]
         out[scalar][i] = np.median(vals[flag==1])
     return out
@@ -703,8 +703,8 @@ def treece_thickness(args: Namespace) -> None:
     if ~args.silent:
         message("Calculate mean and standard deviation of thickness...")
     thickness = surface["thickness"][surface["use_point"] == 1]
-    mean_thickness = np.mean(thickness)
-    std_thickness = np.std(thickness)
+    mean_thickness = np.mean(thickness[thickness>0])
+    std_thickness = np.std(thickness[thickness>0])
 
     if ~args.silent:
         message("Writing log file...")

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -402,14 +402,6 @@ def treece_thickness(args: Namespace):
     if ~args.silent:
         message("Done.")
 
-    # the steps for the procedure:
-    # 11. compute the mean and st.dev of cortical thickness and save to a log file
-    # STILL NEED TO IMPLEMENT THE LOGGING
-    # LOG THE MEAN AND STANDARD DEVIATION OF THICKNESS
-    # ALSO MAKE NOTE OF ANY THICKNESSES WHICH ARE NEGATIVE OR LARGER THAN THE SAMPLE LINE
-    # MAKE NOTE OF THESE AND THE LOCATION OF THE VOXEL AND NOTE THEM IN THE LOG FILE
-    # OR MAYBE IN A SEPARATE ERROR LOG FILE
-
 
 def create_parser() -> ArgumentParser:
     parser = ArgumentParser(

--- a/bonelab/cli/treece_thickness.py
+++ b/bonelab/cli/treece_thickness.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+# IMPORTS
+# external
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace, ArgumentTypeError
+from typing import Callable, Tuple
+import pyvista as pv
+import numpy as np
+import SimpleITK as sitk
+from tqdm import tqdm
+from skimage.morphology import binary_erosion, binary_dilation
+from matplotlib import pyplot as plt
+from scipy.optimize import least_squares
+
+# internal
+from bonelab.util.registration_util import (
+    create_file_extension_checker, read_image,
+    check_inputs_exist, check_for_output_overwrite
+)
+from bonelab.util.echo_arguments import echo_arguments
+from bonelab.util.time_stamp import message
+
+
+# CONSTANTS
+# define file extensions that we consider available for input images
+INPUT_EXTENSIONS = [".nii", ".nii.gz"]
+
+
+# FUNCTIONS
+def indefinite_integral(x: np.ndarray, dx: float) -> np.ndarray:
+    '''
+    Compute the indefinite integral of x with respect to dx.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        The function to integrate.
+
+    dx : float
+        The spacing between values in x.
+
+    Returns
+    -------
+    np.ndarray
+        The indefinite integral of x with respect to dx.
+    '''
+    return np.cumsum(x) * dx
+
+def create_treece_model(
+    y1: float, r: float, dx: float
+) -> Callable[[np.ndarray, float, float, float, float, float], np.ndarray]:
+    '''
+    Create a model function for Treece' method.
+
+    Parameters
+    ----------
+    y1 : float
+        The density of the tissue between x0 and x1 (cortical bone).
+
+    r : float
+        Half of the value of the out-of-plane blur effect caused by the misalignment
+        of the cortical surface and the slice orientation.
+
+    dx : float
+        The spacing between values in x (spatial resolution of the discrete parameterized line).
+
+    Returns
+    -------
+    Callable[[np.ndarray, float, float, float, float, float], float]
+        A function for Treece' model with y1 and r fixed.
+    '''
+    sqrtpi = np.sqrt(np.pi)
+
+    def model(x: np.ndarray, x0: float, x1: float, y0: float, y2: float, sigma: float) -> np.ndarray:
+        '''
+        A model that predicts the intensity at a given location on a parameterized line normal to
+        the cortical surface based on a function with two step functions and some blurring.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            The locations along the parameterized line where the intensities are measured.
+
+        x0 : float
+            The location of the first step function.
+
+        x1 : float
+            The location of the second step function.
+
+        y0 : float
+            The density outside the cortical bone (soft tissue).
+
+        y2 : float
+            The density past the cortical bone (marrow and trabecular bone).
+
+        sigma : float
+            The standard deviation of the Gaussian blur approximating in-plane partial volume effects
+            and other blurring effects from the measurement system.
+
+        Returns
+        -------
+        np.ndarray
+            The predicted intensities at the locations x.
+        '''
+        integrand = (
+            (y1 - y0) / (2*r*sigma*sqrtpi) * (
+                np.exp(-(x+r-x0)**2/(sigma**2)) - np.exp(-(x-r-x0)**2/(sigma**2))
+            )
+            + (y2 - y1) / (2*r*sigma*sqrtpi) * (
+                np.exp(-(x+r-x1)**2/(sigma**2)) - np.exp(-(x-r-x1)**2/(sigma**2))
+            )
+        )
+        return y0 + indefinite_integral(indefinite_integral(integrand, dx), dx)
+
+    return model
+
+
+def create_treece_residual_function(
+    model: Callable[[np.ndarray, float, float, float, float, float], np.ndarray],
+    intensities: np.ndarray,
+    x: np.ndarray,
+    residual_boost_factor: float = 2.0
+) -> Callable[[Tuple[float, float, float, float, float]], np.ndarray]:
+    '''
+    Create a residual function for Treece' method to fit the model using least squares.
+
+    Parameters
+    ----------
+    model : Callable[[np.ndarray, float, float, float, float, float], float]
+        The model function to fit.
+
+    intensities: np.ndarray
+        The measured intensities at the locations x.
+
+    x : np.ndarray
+        The locations along the parameterized line where the intensities were measured.
+
+    Returns
+    -------
+    Callable[[Tuple[float, float, float, float, float]], np.ndarray]
+        A function that computes the residuals between the model and the measured intensities.
+    '''
+    def residual_function(args: Tuple[float, float, float, float, float]) -> np.ndarray:
+        '''
+        Compute the residuals between the model and the measured intensities.
+        '''
+        modelled_intensities = model(x, *args)
+        mult = np.linspace(residual_boost_factor, 1, len(x))
+        return mult * (modelled_intensities - intensities)
+
+    return residual_function
+
+
+def treece_fit(
+    intensities: np.ndarray,
+    x: np.ndarray,
+    normal: np.ndarray,
+    dx: float,
+    y1: float,
+    residual_boost_factor: float,
+    slice_thickness: float,
+    cortical_threshold: float,
+    y0_initial_guess: float,
+    y2_initial_guess: float,
+    sigma_initial_guess: float,
+
+) -> Tuple[float, float, np.ndarray]:
+    '''
+    Fit the Treece' model to the measured intensities and normal and return the location
+    where the cortical bone starts and ends.
+
+    Parameters
+    ----------
+    intensities : np.ndarray
+        The measured intensities at the locations x.
+
+    x : np.ndarray
+        The locations along the parameterized line where the intensities were measured.
+
+    normal : np.ndarray
+        The normal vector to the cortical surface at the locations x.
+
+    dx : float
+        The spacing between values in x (spatial resolution of the discrete parameterized line).
+
+    y1 : float
+        The density of the tissue between x0 and x1 (cortical bone).
+
+    residual_boost_factor : float
+        A factor to boost the residuals near the start of the line to make the model fit better
+        to the first peak which will correspond to the cortical bone and less likely to be
+        influenced by subsequent peaks, which will correspond to trabecular bone in high-res images.
+
+    slice_thickness : float
+        The thickness of the slice in the direction of the normal.
+
+    cortical_threshold : float
+        The threshold to determine the initial guess for the start of the cortical bone.
+
+    y0_initial_guess : float
+        The initial guess for the density outside the cortical bone (soft tissue).
+
+    y2_initial_guess : float
+        The initial guess for the density past the cortical bone (marrow and trabecular bone).
+
+    sigma_initial_guess : float
+        The initial guess for the standard deviation of the Gaussian blur approximating in-plane
+        partial volume effects and other blurring effects from the measurement system.
+
+    Returns
+    -------
+    Tuple[float, float, np.ndarray]
+        The distance along the line where the cortical bone starts and ends,
+        and the modelled intensities for debug purposes.
+    '''
+    r = (
+        (slice_thickness / 2)
+        * np.abs(normal[2])
+        / np.sqrt(normal[0]**2 + normal[1]**2)
+    )
+
+    x0 = [
+        x[list(intensities > cortical_threshold).index(True)],
+        x[list(intensities > cortical_threshold).index(True) + 10],
+        y0_initial_guess,
+        y2_initial_guess,
+        sigma_initial_guess
+    ]
+
+    model = create_treece_model(y1, r, dx)
+    residual_function = create_treece_residual_function(model, intensities, x, residual_boost_factor)
+
+    result = least_squares(residual_function, x0=x0, method="lm")
+    return result.x[0], result.x[1], model(x, *result.x)
+
+
+def compute_boundary_mask(mask: np.ndarray) -> np.ndarray:
+    eroded_mask = binary_erosion(mask, selem=np.ones((3,3,3)))
+    return mask - eroded_mask
+
+
+def sample_intensity_profile(
+    image: pv.UniformGrid,
+    point: np.ndarray,
+    normal: np.ndarray,
+    outside_dist: float,
+    inside_dist: float,
+    dx: float
+) -> Tuple[np.ndarray, np.ndarray]:
+    normal = normal / np.sqrt((normal**2).sum())
+    x = np.arange(-outside_dist, inside_dist, dx)
+    sample_points = pv.PolyData(point[np.newaxis,:] + x[:,np.newaxis]*normal[np.newaxis,:])
+    sample_points = sample_points.sample(image)
+    return np.array(sample_points["NIFTI"]), x
+
+
+def treece_thickness(args: Namespace):
+    print(echo_arguments("Treece Thickness", vars(args)))
+    input_fns = [args.bone_mask, args.image]
+    if args.sub_mask:
+        input_fns.append(args.sub_mask)
+    check_inputs_exist(input_fns, args.silent)
+    output_image = f"{args.output_base}.nii.gz"
+    output_log = f"{args.output_base}.log"
+    check_for_output_overwrite([output_image, output_log], args.overwrite, args.silent)
+    if ~args.silent:
+        message("Reading in the image...")
+    image = pv.read(args.image) #pv.wrap(reader.GetOutput())
+    if ~args.silent:
+        message("Determining the line resolution, if not given...")
+    dx = args.line_resolution if args.line_resolution else min(image.spacing) / 10
+    if ~args.silent:
+        message("Reading in the bone mask...")
+    bone_mask = pv.read(args.bone_mask) #pv.wrap(reader.GetOutput())
+    if args.sub_mask:
+        if ~args.silent:
+            message("Reading in the sub-mask...")
+        sub_mask = pv.read(args.sub_mask) #pv.wrap(reader.GetOutput())
+    else:
+        if ~args.silent:
+            message("No sub-mask provided. Proceeding without it...")
+        sub_mask = None
+    if ~args.silent:
+        message("Computing the boundary voxels...")
+    bone_mask["boundary"] = compute_boundary_mask(bone_mask.active_scalars.reshape(bone_mask.dimensions, order="F")).flatten(order="F")
+    if args.sub_mask:
+        if ~args.silent:
+            message("Using only the boundary voxels in the sub-mask...")
+        bone_mask["boundary"] = bone_mask["boundary"] * sub_mask["NIFTI"]
+    if ~args.silent:
+        message("Computing the bone surface...")
+    bone_surface = bone_mask.contour([1], scalars="NIFTI", progress_bar=~args.silent)
+    if args.smooth_surface:
+        if ~args.silent:
+            message("Smoothing the surface...")
+        bone_surface = bone_surface.smooth_taubin(
+            n_iter=args.surface_smoothing_iterations,
+            pass_band=args.surface_smoothing_passband,
+            progress_bar=~args.silent
+        )
+    else:
+        if ~args.silent:
+            message("Not smoothing the surface...")
+    if ~args.silent:
+        message("Computing the normals...")
+    bone_surface = bone_surface.compute_normals(
+        auto_orient_normals=True,
+        flip_normals=True,
+        progress_bar=~args.silent
+    )
+    if ~args.silent:
+        message("Resampling the surface normals back to the boundary voxels...")
+    bone_mask = bone_mask.interpolate(
+        bone_surface,
+        strategy="closest_point",
+        progress_bar=~args.silent
+    )
+    bone_mask["Normals"] = bone_mask["Normals"] * bone_mask["boundary"][:,np.newaxis]
+    if ~args.silent:
+        message("Computing the cortical thickness at each boundary voxel...")
+    bone_mask["thickness"] = np.zeros((bone_mask.n_points,))
+    for i in tqdm(np.where(bone_mask["boundary"] == 1)[0], disable=args.silent):
+        intensities, x = sample_intensity_profile(
+            image,
+            bone_mask.points[i,:],
+            bone_mask["Normals"][i,:],
+            args.sample_outside_distance,
+            args.sample_inside_distance,
+            dx
+        )
+        x0, x1, model_intensities = treece_fit(
+            intensities,
+            x,
+            bone_mask["Normals"][i,:],
+            dx,
+            args.cortical_density,
+            args.residual_boost_factor,
+            image.spacing[2], # assuming that we want the z-spacing for slice thickness
+            args.cortical_threshold,
+            args.soft_tissue_intensity_initial_guess,
+            args.trabecular_bone_intensity_initial_guess,
+            args.model_sigma_initial_guess,
+        )
+        bone_mask["thickness"][i] = x1 - x0
+
+        if args.debug_check_model_fit or (x1 < x0):
+            plt.figure()
+            plt.plot(x, intensities, "k-")
+            plt.plot(x, model_intensities, "r--")
+            plt.axvline(x0, color="black", linestyle="--")
+            plt.axvline(x1, color="black", linestyle="--")
+            plt.xlabel("x")
+            plt.ylabel("intensity")
+            plt.show()
+            break
+
+    if ~args.silent:
+        message("Writing the cortical thickness image to disk...")
+    thickness = bone_mask["thickness"].reshape(bone_mask.dimensions, order="F")
+    thickness = sitk.GetImageFromArray(thickness)
+    thickness.SetSpacing(image.spacing)
+    thickness.SetOrigin(image.origin)
+    sitk.WriteImage(thickness, output_image)
+    # the steps for the procedure:
+    # 9. use Treece' algorithm to compute the cortical thickness at every voxel on the boundary (and within the sub-mask)
+    # 10. write the cortical thickness image to disk
+    # 11. compute the mean and st.dev of cortical thickness and save to a log file
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        description="Use a modified version of Treece' method (doi:10.1016/j.media.2010.01.003) to compute "
+                    "a cortical thickness map from an image, a bone mask, and an optional sub-mask.",
+        formatter_class=ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "image", type=create_file_extension_checker(INPUT_EXTENSIONS, "image"), metavar="IMAGE",
+        help=f"Provide image input filename ({', '.join(INPUT_EXTENSIONS)})"
+    )
+    parser.add_argument(
+        "bone_mask", type=create_file_extension_checker(INPUT_EXTENSIONS, "bone mask"), metavar="BONE_MASK",
+        help=f"Provide bone mask input filename ({', '.join(INPUT_EXTENSIONS)})"
+    )
+    parser.add_argument(
+        "output_base", type=str, metavar="OUTPUT",
+        help=f"Provide base for outputs, you will get a file `output`.nii.gz and `output`.log"
+    )
+    parser.add_argument(
+        "--sub-mask", type=create_file_extension_checker(INPUT_EXTENSIONS, "sub-mask"), default=None, metavar="SUB_MASK",
+        help=f"Provide optional sub-mask input filename ({', '.join(INPUT_EXTENSIONS)})"
+    )
+
+    parser.add_argument(
+        "--smooth-surface", "-ss",  default=False, action="store_true",
+        help="enable this flag to smooth the bone surface before computing the normals"
+    )
+    parser.add_argument(
+        "--surface-smoothing-iterations", "-ssi", type=int, default=15,
+        help="number of iterations for the Taubin surface smoothing"
+    )
+    parser.add_argument(
+        "--surface-smoothing-passband", "-ssp", type=float, default=0.1,
+        help="passband for the Taubin surface smoothing"
+    )
+    parser.add_argument(
+        "--cortical-density", "-cd", type=float, default=800,
+        help="prescribed cortical density, in the units of the image, for the model"
+    )
+    parser.add_argument(
+        "--line-resolution", "-lr", type=float, default=None,
+        help="resolution of the line in the Treece' algorithm, in physical spatial units of the image."
+             "If not provided, will default to 1/10 the smallest voxel size"
+    )
+    parser.add_argument(
+        "--residual-boost-factor", "-rbf", type=float, default=3.0,
+        help="boost factor for the residuals near the start of the line in the Treece' algorithm"
+    )
+    parser.add_argument(
+        "--sample-outside-distance", "-sod", type=float, default=3,
+        help="distance outside the boundary to sample the intensities for the Treece' algorithm"
+    )
+    parser.add_argument(
+        "--sample-inside-distance", "-sid", type=float, default=8,
+        help="distance inside the boundary to sample the intensities for the Treece' algorithm"
+    )
+    parser.add_argument(
+        "--cortical-threshold", "-ct", type=float, default=800,
+        help="threshold for the cortical bone, used only to decide where to place the initial guesses for x0, x1"
+    )
+    parser.add_argument(
+        "--soft-tissue-intensity-initial-guess", "-stig", type=float, default=0,
+        help="initial guess for the intensity of soft tissue in the model"
+    )
+    parser.add_argument(
+        "--trabecular-bone-intensity-initial-guess", "-tbig", type=float, default=200,
+        help="initial guess for the intensity of trabecular bone in the model"
+    )
+    parser.add_argument(
+        "--model-sigma-initial-guess", "-msig", type=float, default=1,
+        help="initial guess for the sigma of inplane blurring in the model"
+    )
+
+    parser.add_argument(
+        "--overwrite", "-ow", default=False, action="store_true",
+        help="enable this flag to overwrite existing files, if they exist at output targets"
+    )
+    parser.add_argument(
+        "--silent", "-s", default=False, action="store_true",
+        help="enable this flag to suppress terminal output"
+    )
+    parser.add_argument(
+        "--debug-check-model-fit", "-dcmf", default=False, action="store_true",
+        help="enable this flag to plot the model fit for one boundary voxel, for debugging purposes"
+    )
+
+
+
+    return parser
+
+
+def main():
+    args = create_parser().parse_args()
+    treece_thickness(args)
+
+if __name__ == "__main__":
+    main()

--- a/bonelab/io/download_data.py
+++ b/bonelab/io/download_data.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import os
 
 # Default URL
-BL_DATA_DEFAULT_URL = 'https://github.com/Bonelab/BonelabData/trunk/data/'
+BL_DATA_DEFAULT_URL = 'https://github.com/Bonelab/BonelabData.git'
 
 # Environment variable for user defined bonelab data directory
 BL_DATA_DIRECTORY_ENVIRONMENT_VARIABLE = 'BL_DATA_DIRECTORY'

--- a/examples/python/blTreeceThickness/create_sample_data.py
+++ b/examples/python/blTreeceThickness/create_sample_data.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, Namespace, ArgumentTypeError
+import os
+
+import numpy as np
+import SimpleITK as sitk
+
+
+def create_sample_data(args: Namespace):
+    x, y, z = np.meshgrid(
+        np.linspace(-args.img_size//2, args.img_size//2, args.img_size),
+        np.linspace(-args.img_size//2, args.img_size//2, args.img_size),
+        np.linspace(-args.img_size//2, args.img_size//2, args.img_size)
+    )
+
+    img = args.soft_tissue_intensity * np.ones_like(x)
+    cortical = (
+        ((x**2 + y**2 + z**2) < args.outer_radius**2)
+        & ((x**2 + y**2 + z**2) > args.inner_radius**2)
+    )
+    interior = (x**2 + y**2 + z**2) < args.inner_radius**2
+    img[cortical] = args.cortical_bone_intensity
+    img[interior] = args.interior_bone_intensity
+
+    mask = ((x**2 + y**2 + z**2) < args.outer_radius**2).astype(int)
+    sub_mask = mask.copy()
+    sub_mask[~((x>0)&(y>0)&(z>0))] = 0
+
+    img = sitk.GetImageFromArray(img)
+    mask = sitk.GetImageFromArray(mask)
+    sub_mask = sitk.GetImageFromArray(sub_mask)
+
+    img = sitk.RecursiveGaussian(img, sigma=args.smoothing_sigma)
+    img = sitk.AdditiveGaussianNoise(img, args.noise)
+
+    try:
+        os.makedirs(args.dir)
+    except FileExistsError:
+        pass
+
+    sitk.WriteImage(img, os.path.join(args.dir, f"{args.name}.nii.gz"))
+    sitk.WriteImage(mask, os.path.join(args.dir, f"{args.name}_mask.nii.gz"))
+    sitk.WriteImage(sub_mask, os.path.join(args.dir, f"{args.name}_sub_mask.nii.gz"))
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser(
+        description="Create sample data for testing.",
+        formatter_class=ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "dir", type=str, metavar="DIR",
+        help="The directory in which to create the sample data."
+    )
+    parser.add_argument(
+        "name", type=str, metavar="NAME",
+        help="The name for the sample data."
+    )
+    parser.add_argument(
+        "--img-size", "-is", type=int, default=50, metavar="SIZE",
+        help="The size of the sample data."
+    )
+    parser.add_argument(
+        "--inner-radius", "-ir", type=int, default=15, metavar="INNER_RADIUS",
+        help="The inner radius of the fake bone in the sample data."
+    )
+    parser.add_argument(
+        "--outer-radius", "-or", type=int, default=20, metavar="OUTER_RADIUS",
+        help="The outer radius of the fake bone in the sample data."
+    )
+    parser.add_argument(
+        "--soft-tissue-intensity", "-sti", type=float, default=100, metavar="SOFT_TISSUE_INTENSITY",
+        help="The intensity of the soft tissue in the sample data."
+    )
+    parser.add_argument(
+        "--cortical-bone-intensity", "-cbi", type=float, default=1000, metavar="CORTICAL_BONE_INTENSITY",
+        help="The intensity of the cortical bone in the sample data."
+    )
+    parser.add_argument(
+        "--interior-bone-intensity", "-ibi", type=float, default=400, metavar="INTERIOR_BONE_INTENSITY",
+        help="The intensity of the interior bone in the sample data."
+    )
+    parser.add_argument(
+        "--smoothing-sigma", "-ss", type=float, default=1, metavar="SMOOTHING_SIGMA",
+        help="The sigma for the gaussian smoothing filter to apply before adding noise."
+    )
+    parser.add_argument(
+        "--noise", "-n", type=float, default=100, metavar="NOISE",
+        help="The variance of the gaussian noise to add to the sample data."
+    )
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    create_sample_data(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ vtk
 simpleitk
 pydicom
 scikit-image
+pyvista
 
 # Numerics
 numpy
@@ -19,6 +20,7 @@ matplotlib
 pandas
 openpyxl
 pyyaml
+tqdm
 
 # Writing video
 ffmpeg

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pbr
 nose
 six
 hypothesis
+gitpython
 
 # Image processing
 vtk

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ hypothesis
 
 # Image processing
 vtk
-simpleitk
+simpleitk==2.2
 pydicom
 scikit-image
 pyvista

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ console_scripts =
     blRegistrationLongitudinal = bonelab.cli.longitudinal_registration:main
     blAdaptiveLocalThresholding = bonelab.cli.adaptive_local_thresholding:main
     blFFTLaplaceHamming = bonelab.cli.fft_laplace_hamming:main
+    blTreeceThickness = bonelab.cli.treece_thickness:main
 
 [pbr]
 skip_changelog = 1

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -49,7 +49,6 @@ class TestCommandLineInterfaceRun(unittest.TestCase):
         # Remove temporary directory and all files
         shutil.rmtree(self.test_dir)
 
-    @unittest.skip("The download is messed up, not sure why right now")
     def test_blDownloadData(self):
         '''Can run `blDownloadData`'''
         directory = os.path.join(self.test_dir, 'bldata')

--- a/tests/cli/test_cli_run.py
+++ b/tests/cli/test_cli_run.py
@@ -49,6 +49,7 @@ class TestCommandLineInterfaceRun(unittest.TestCase):
         # Remove temporary directory and all files
         shutil.rmtree(self.test_dir)
 
+    @unittest.skip("The download is messed up, not sure why right now")
     def test_blDownloadData(self):
         '''Can run `blDownloadData`'''
         directory = os.path.join(self.test_dir, 'bldata')

--- a/tests/cli/test_cli_setup.py
+++ b/tests/cli/test_cli_setup.py
@@ -125,6 +125,10 @@ class TestCommandLineInterfeceSetup(unittest.TestCase):
         ''' Can run `blFFTLaplaceHamming` '''
         self.runner('blFFTLaplaceHamming')
 
+    def test_blTreeceThickness(self):
+        ''' Can run `blTreeceThickness` '''
+        self.runner('blTreeceThickness')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -82,8 +82,8 @@ def download_testing_data(filename):
     On success, this function returns the full file path. On failure,
     an empty string is returned.
     '''
-    input_uri = cfg['REGRESSION_DATA_URL'] + filename
-    output_uri = os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)
+    input_uri = cfg['REGRESSION_DATA_URL']
+    output_uri = cfg['REGRESSION_DATA_DIRECTORY']
 
     # Create output directory if it doesn't exist
     if not os.path.exists(cfg['REGRESSION_DATA_DIRECTORY']):
@@ -109,4 +109,5 @@ def download_testing_data(filename):
             output_uri
         )
     shutil.rmtree(os.path.join(output_uri, "BonelabData"))
+    return os.path.join(cfg['REGRESSION_DATA_URL'], cfg['REGRESSION_DATA_DIRECTORY'])
 cfg['DOWNLOAD_TESTING_DATA'] = download_testing_data

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -109,5 +109,5 @@ def download_testing_data(filename):
             output_uri
         )
     shutil.rmtree(os.path.join(output_uri, "BonelabData"))
-    return os.path.join(cfg['REGRESSION_DATA_URL'], cfg['REGRESSION_DATA_DIRECTORY'])
+    return os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)
 cfg['DOWNLOAD_TESTING_DATA'] = download_testing_data

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -82,33 +82,24 @@ def download_testing_data(filename):
     On success, this function returns the full file path. On failure,
     an empty string is returned.
     '''
-    input_uri = cfg['REGRESSION_DATA_URL']
-    output_uri = cfg['REGRESSION_DATA_DIRECTORY']
 
     # Create output directory if it doesn't exist
     if not os.path.exists(cfg['REGRESSION_DATA_DIRECTORY']):
         os.makedirs(cfg['REGRESSION_DATA_DIRECTORY'])
 
     # If we have already downloaded it, skip
-    if os.path.exists(output_uri):
-        return output_uri
+    if os.path.exists(os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)):
+        return os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)
 
     # Download
-    '''
-    command = ['svn', 'export', input_uri, output_uri]
-    if cfg['RUN_CALL'](command):
-        return output_uri
-    else:
-        return ''
-    '''
-    repo = Repo.clone_from(input_uri, os.path.join(output_uri, "BonelabData"))
-    data_files = os.listdir(os.path.join(output_uri, "BonelabData", "data"))
+    repo = Repo.clone_from(cfg['REGRESSION_DATA_URL'], os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], "BonelabData"))
+    data_files = os.listdir(os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], "BonelabData", "data"))
     shutil.move(
-        os.path.join(output_uri, "BonelabData", "data", filename),
+        os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], "BonelabData", "data", filename),
         cfg['REGRESSION_DATA_DIRECTORY']
     )
-    shutil.rmtree(os.path.join(output_uri, "BonelabData"))
-    print(filename)
-    print(os.listdir(cfg['REGRESSION_DATA_DIRECTORY']))
+    shutil.rmtree(os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], "BonelabData"))
     return os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)
+
+
 cfg['DOWNLOAD_TESTING_DATA'] = download_testing_data

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -1,6 +1,7 @@
 # See https://github.com/Numerics88/n88tools/blob/master/tests/regression/config_regression.py for how this file was defined
 
 import os
+import shutil
 import subprocess
 
 '''
@@ -73,9 +74,9 @@ cfg['RUN_CALL'] = run_call
 # Create download script
 def download_testing_data(filename):
     '''Download data used in testing
-    
+
     Typically, this is done for regression testing.
-    
+
     On success, this function returns the full file path. On failure,
     an empty string is returned.
     '''
@@ -85,16 +86,25 @@ def download_testing_data(filename):
     # Create output directory if it doesn't exist
     if not os.path.exists(cfg['REGRESSION_DATA_DIRECTORY']):
         os.makedirs(cfg['REGRESSION_DATA_DIRECTORY'])
-    
+
     # If we have already downloaded it, skip
     if os.path.exists(output_uri):
         return output_uri
 
     # Download
+    '''
     command = ['svn', 'export', input_uri, output_uri]
     if cfg['RUN_CALL'](command):
         return output_uri
     else:
         return ''
+    '''
+    repo = Repo.clone_from(input_uri, os.path.join(output_uri, "BonelabData"))
+    data_files = os.listdir(os.path.join(output_uri, "BonelabData", "data"))
+    for data_file in data_files:
+        shutil.move(
+            os.path.join(output_uri, "BonelabData", "data", data_file),
+            output_uri
+        )
+    shutil.rmtree(os.path.join(output_uri, "BonelabData"))
 cfg['DOWNLOAD_TESTING_DATA'] = download_testing_data
-

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -34,7 +34,7 @@ cfg['REGRESSION_FILES'] = [
     'bpaq_output.csv'
 ]
 
-cfg['REGRESSION_DATA_URL'] = "https://github.com/Bonelab/BonelabData/trunk/data/"
+cfg['REGRESSION_DATA_URL'] = "https://github.com/Bonelab/BonelabData.git"
 
 cfg['REGRESSION_DATA_DIRECTORY'] = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), 'data'
@@ -103,11 +103,12 @@ def download_testing_data(filename):
     '''
     repo = Repo.clone_from(input_uri, os.path.join(output_uri, "BonelabData"))
     data_files = os.listdir(os.path.join(output_uri, "BonelabData", "data"))
-    for data_file in data_files:
-        shutil.move(
-            os.path.join(output_uri, "BonelabData", "data", data_file),
-            output_uri
-        )
+    shutil.move(
+        os.path.join(output_uri, "BonelabData", "data", filename),
+        cfg['REGRESSION_DATA_DIRECTORY']
+    )
     shutil.rmtree(os.path.join(output_uri, "BonelabData"))
+    print(filename)
+    print(os.listdir(cfg['REGRESSION_DATA_DIRECTORY']))
     return os.path.join(cfg['REGRESSION_DATA_DIRECTORY'], filename)
 cfg['DOWNLOAD_TESTING_DATA'] = download_testing_data

--- a/tests/config_cli.py
+++ b/tests/config_cli.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import subprocess
 
+from git import Repo
+
 '''
 A set of helper variables and functions for running tests.
 


### PR DESCRIPTION
I've added a utility for computing Ct.Th / Sc.Th using Treece method. I think maybe this could be an improvement over the Hildebrand method for the knee HR-pQCT images because the Sc.Th estimate will be based only on densities and not on the endosteal segmentation, which is really difficult on the knees.

It could also be applied to clinical CT. We will likely need to test this a bunch and maybe some mopre refinements to the code will be required.

I have also constrained the version of `SimpleITK` to 2.2 in `requirement.txt`
I think this will fix the issue with the automated tests taking a really long time on the Github actions CI workflow. I think the problem is that `SimpleITK` released version 2.3 recently, but we are stuck on Python 3.7 because of `n88tools` and there is no precompiled wheel for `SimpleITK v2.3` with 3.7 of Python, so instead pip downloads some source code and compiles `SimpleITK`. I tested it locally and constraining the version dramatically sped up the pip install process since there is a wheel for `SimpleITK v2.2` with python 3.7.

also fixes #16 