### PR TITLE
Convert seg array to int for SITK

### DIFF
--- a/bonelab/cli/adaptive_local_thresholding.py
+++ b/bonelab/cli/adaptive_local_thresholding.py
@@ -194,7 +194,7 @@ def adaptive_local_thresholding(args: Namespace):
         writer.SetFileName(args.output)
         writer.Update()
     else:
-        segmentation_sitk = sitk.GetImageFromArray(segmentation)
+        segmentation_sitk = sitk.GetImageFromArray(segmentation.astype(int))
         segmentation_sitk.CopyInformation(image_sitk)
         sitk.WriteImage(segmentation_sitk, args.output)
 


### PR DESCRIPTION
Converting NumPy arrays to SimpleITK images does not work with a boolean array. Casting the array to an integer array fixes this issue.